### PR TITLE
Fix code documentation typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ mymodel.get_probability_matrices()
 
 It is also able to visualize the transitions:
 ```
-mymodel.plot(outputdirectory='/path/to/store/output', user='anna')      
+mymodel.plot(outputdirectory='/path/to/store/output', user='Anna')      
 ```
 
 Convert to common graphic formats:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mymodel.plot(outputdirectory='/path/to/store/output', user='Anna')
 
 Convert to common graphic formats:
 ```
-dot -Tpng anna_markov.dot >anna_markov.png
+dot -T png Anna_probabilities.dot > anna_markov.png
 ```
 
 ### Aggregate sequential patterns:


### PR DESCRIPTION
Hello, 

I came across your GitHub repository after reading your paper. When proceeding to run the code as per instructed from the `README.md` I encountered a simple error due to a typo in a sample code line and am submitting this pull request to fix it.